### PR TITLE
Revamped initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ end
 
 # ... somewhere early in execution ..."
 
-MyAppConfig.initialize_from_yaml('config/values.yaml')
+MyAppConfig.init_with(:yaml, 'config/values.yaml')
 
 # ... later on in the app ...
 
@@ -137,14 +137,14 @@ configuration that may disrupt subsequent examples.
 
 Populate with values from environment
 -------------------------------------
-The ```initialize_from_env``` method populates values from the environment. Konfa will only import variables with a specific prefix to avoid collisions with existing variables.
+Calling ```init_with(:env)``` populates values from the environment. Konfa will only import variables with a specific prefix to avoid collisions with existing variables.
 
 ```ruby
 # in myapp.rb
 class MyAppConfig < Konfa::Base
 
   def self.env_variable_prefix
-    'MY_APP'
+    'MY_APP_'
   end
 
   def self.allowed_variables
@@ -155,7 +155,7 @@ class MyAppConfig < Konfa::Base
   end
 end
 
-MyAppConfig.initialize_from_env
+MyAppConfig.init_with(:env)
 
 puts "I speak #{MyAppConfig.get(:lang)} and I will #{MyAppConfig.true?(:show_stuff) ? "" : "not"} show stuff"
 ```
@@ -172,7 +172,7 @@ I speak pt and I will not show stuff
 
 Populate with values from YAML
 ------------------------------
-The ```initialize_from_yaml``` will read values from the given yaml file. Only key/values are supported.
+The YAML initializer will read values from the given yaml file. Only key/values are supported.
 
 *Note on YAML and booleans*
 
@@ -209,31 +209,80 @@ class MyAppConfig < Konfa::Base
 end
 ```
 
-initialize_deferred
+Notes on initializing
 -------------------
-Sometimes a Konfa subclass cannot immediately perform its initialization routine
-when it is declared, if for example a database connection is established after
-Konfa is set up. This is when ```initialize_deferred``` comes in handy. It's used
-like so:
+
+## Initialization is deferred by default
+
+Konfa will initialize its values when a variable is first read (when for instance
+calling `get`, `true?` or `dump`). Initialization can be triggered earlier by calling
+the `init`method.
+
+The default behaviour:
 
 ```ruby
 
-MyAppConfig.initialize_deferred(:initialize_from_yaml, 'path_to_yaml_file')
+MyAppConfig.init_with(:yaml), 'path_to_yaml_file')
 
 # ... things happens, and later on in the execution:
 
-MyAppConfig.get(:the_value)
+MyAppConfig.get(:my_var) # Konfa will read the yaml file, populate the
+                         # configuration and then return the value of `my_var`
 ```
 
-The first call to ```get``` (or ```true?``` or ```false?```) will trigger the
-initialization and populate Konfa with values before returning the correspoding value.
+Initialize earlier:
 
-You may pass in any initialization routine to the call, including one declared by the subclass.
+```ruby
+
+MyAppConfig.init_with(:yaml), 'path_to_yaml_file')
+
+MyAppConfig.init # Konfa will now read the yaml file and populate the configuration
+                 # It's also possible to chain:
+                 #     MyAppConfig.init_with(:yaml, '...').init
+
+# ... things happens, and later on in the execution:
+
+MyAppConfig.get(:my_var)
+```
 
 From a design perspective, it is desireble to initialize Konfa as early as possible,
 as it will fail early if bad configuration values are found. Do not use this method
 unless there is a good reason to.
 
-You may override the ```do_deferred_initialization?``` method for implementing own logic
-on when to run the initialization code. This method is invoked at every time a value is
+You may override the ```init?``` method for implementing own logic on when to
+run the initialization code. This method is invoked at every time a value is
 accessed.
+
+## Custom initialization methods
+
+If you want to initialize Konfa with values from another source (for example a
+database), you need to implement an initialization method. Extend the module
+`Konfa::Initializer::ClassMethods` with your own method and call `init_with`.
+
+***NOTE:*** your initializer method name must be prefixed with: `init_with_` to
+avoid collisions in the configuration class.
+
+```ruby
+
+module Konfa
+  module Initializer
+    module ClassMethods
+      def init_with_numbers
+        self.store('my_var', '01234')
+      end
+    end
+  end
+end
+
+class MyAppConfig < Konfa::Base
+  def self.allowed_variables
+    {
+      my_var: nil,
+    }
+  end
+end
+
+MyAppConfig.init_with(:numbers) # Don't include prefix in symbol
+
+MyAppConfig.get(:my_var) # => 01234
+```

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ The default behaviour:
 
 ```ruby
 
-MyAppConfig.init_with(:yaml), 'path_to_yaml_file')
+MyAppConfig.init_with(:yaml, 'path_to_yaml_file')
 
 # ... things happens, and later on in the execution:
 
@@ -234,7 +234,7 @@ Initialize earlier:
 
 ```ruby
 
-MyAppConfig.init_with(:yaml), 'path_to_yaml_file')
+MyAppConfig.init_with(:yaml, 'path_to_yaml_file')
 
 MyAppConfig.init # Konfa will now read the yaml file and populate the configuration
                  # It's also possible to chain:

--- a/konfa.gemspec
+++ b/konfa.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
   s.name        = 'konfa'
-  s.version     = '0.3.1'
+  s.version     = '0.4.0'
   s.date        = '2014-11-06'
   s.summary     = "Application configuration"
   s.description = "Helps you avoid common pitfalls when dealing with app config"

--- a/lib/konfa.rb
+++ b/lib/konfa.rb
@@ -7,7 +7,7 @@ module Konfa
       protected
 
       #
-      # The following methods are not a part of the public API. You may sublcass
+      # The following methods are not a part of the public API. You may subclass
       # them, but remember that unless you scope them as protected or private,
       # they will then be public
       #

--- a/lib/konfa.rb
+++ b/lib/konfa.rb
@@ -1,4 +1,3 @@
-require 'yaml'
 require_relative File.join(File.dirname(__FILE__), 'konfa', 'initializer')
 
 module Konfa
@@ -125,9 +124,6 @@ module Konfa
       end
 
     end
-  end
-
-  class InitializationError < StandardError
   end
 
   class UnsupportedVariableError < StandardError

--- a/lib/konfa.rb
+++ b/lib/konfa.rb
@@ -20,7 +20,7 @@ module Konfa
 
       def configuration
         self.init
-        @configuration
+        @configuration ||= self.allowed_variables
       end
 
       def initializer

--- a/lib/konfa.rb
+++ b/lib/konfa.rb
@@ -99,7 +99,7 @@ module Konfa
       end
 
       def init_with(suffix, *args)
-        self.initializer = ["init_with_#{suffix}", *args]
+        self.initializer = [:"init_with_#{suffix}", *args]
         self
       end
 

--- a/lib/konfa/initializer.rb
+++ b/lib/konfa/initializer.rb
@@ -1,3 +1,5 @@
+require 'yaml'
+
 module Konfa
   module Initializer
     def self.included(base)
@@ -12,7 +14,7 @@ module Konfa
         yaml_data = YAML.load_file(path)
 
         unless yaml_data.nil?
-          raise InitializationError.new("Bad YAML format, key/value pairs expected") unless yaml_data.kind_of?(Hash)
+          raise Konfa::InitializationError.new("Bad YAML format, key/value pairs expected") unless yaml_data.kind_of?(Hash)
 
           yaml_data.each do |variable, value|
             self.store(variable, value)
@@ -37,5 +39,8 @@ module Konfa
       end
     end
 
+  end
+
+  class InitializationError < StandardError
   end
 end

--- a/lib/konfa/initializer.rb
+++ b/lib/konfa/initializer.rb
@@ -1,0 +1,41 @@
+module Konfa
+  module Initializer
+    def self.included(base)
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+      def init_with_yaml(path)
+        # FIXME: It would be a lot cleaner if the YAML library would raise an
+        # exception if it fails to read the file. We'll handle it like this for now
+        # load_file just returns "false" if it fails
+        yaml_data = YAML.load_file(path)
+
+        unless yaml_data.nil?
+          raise InitializationError.new("Bad YAML format, key/value pairs expected") unless yaml_data.kind_of?(Hash)
+
+          yaml_data.each do |variable, value|
+            self.store(variable, value)
+          end
+        end
+
+        dump
+      end
+
+      def init_with_env
+        conf_prefix = self.env_variable_prefix.upcase
+
+        ENV.keys.reject { |key|
+          key !~ /^#{conf_prefix}/ # Ignore everything that doesn't match the prefix
+        }.each { |key|
+          variable = key[conf_prefix.size..-1].downcase
+
+          self.store(variable, ENV[key])
+        }
+
+        dump
+      end
+    end
+
+  end
+end

--- a/spec/konfa/initializer_spec.rb
+++ b/spec/konfa/initializer_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+
+describe Konfa::Initializer do
+  let(:bool_file)  { File.expand_path("../../support/bool_config.yaml", __FILE__) }
+  let(:good_file)  { File.expand_path("../../support/good_config.yaml", __FILE__) }
+  let(:bad_file)   { File.expand_path("../../support/bad_config.yaml", __FILE__) }
+  let(:not_yaml)   { File.expand_path("../../support/not_yaml.yaml", __FILE__) }
+  let(:empty_file) { File.expand_path("../../support/empty.yaml", __FILE__) }
+  let(:array_file) { File.expand_path("../../support/array.yaml", __FILE__) }
+
+  # FIXME duplicated in konfa_spec
+  before(:each) do
+    MyTestKonfa.reinit
+    MyTestKonfa.send(:initializer=, nil)
+    MyTestKonfa.send(:configuration=, nil)
+    MyOtherTestKonfa.reinit
+    MyOtherTestKonfa.send(:initializer=, nil)
+    MyOtherTestKonfa.send(:configuration=, nil)
+  end
+
+  context "#init_with_yaml" do
+    it "returns parsed values" do
+      expect(MyTestKonfa.init_with_yaml(good_file)).to eq MyTestKonfa.dump
+    end
+
+    it "raises an exception if file does not contain YAML" do
+      expect {
+        MyTestKonfa.init_with_yaml(not_yaml)
+      }.to raise_error(Konfa::InitializationError)
+    end
+
+    it "raises an exception if file does not key/value pairs" do
+      expect {
+        MyTestKonfa.init_with_yaml(array_file)
+      }.to raise_error(Konfa::InitializationError)
+    end
+
+    it "requires all keys in YAML file to be defined in config class by default" do
+      expect {
+        MyTestKonfa.init_with_yaml(bad_file)
+      }.to raise_error Konfa::UnsupportedVariableError
+    end
+
+    it "handles Ruby's implicit type conversion" do
+      MyTestKonfa.init_with_yaml(bool_file)
+      expect(MyTestKonfa.get :my_var).to be_a(String)
+      expect(MyTestKonfa.get :my_var).to eq 'true'
+    end
+
+    context "when used as an initializer" do
+      it "configures variables from a YAML file" do
+        expect {
+          MyTestKonfa.init_with(:yaml, good_file).init
+        }.to_not raise_error
+        expect(MyTestKonfa.get :my_var).to eq 'read from the yaml file'
+      end
+
+      it "is possible to load an empty file" do
+        expect {
+          MyTestKonfa.init_with(:yaml, empty_file).init
+        }.not_to raise_error
+        expect(MyTestKonfa.get :my_var).to eq 'default value'
+      end
+    end
+  end
+
+  context "#init_with_env" do
+
+    it "prefixes environment variables" do
+      expect(MyTestKonfa.env_variable_prefix).to eq 'PREF_'
+    end
+
+    it "can be initialized with environment variables" do
+      begin
+        ENV["PREF_MY_VAR"] = 'set from env'
+        ENV["IGNORE_MY_VAR"]  = 'should be ignored'
+
+        expect {
+          MyTestKonfa.init_with_env
+        }.not_to raise_error
+
+        expect(MyTestKonfa.get :my_var).to eq 'set from env'
+      ensure
+        ENV.delete("PREF_MY_VAR")
+        ENV.delete("IGNORE_MY_VAR")
+      end
+    end
+
+    it "requires all keys in namespace to be defined in config class by default" do
+      ENV["PREF_BAD_VARIABLE"] = 'should yield an error'
+
+      expect {
+        MyTestKonfa.init_with_env
+      }.to raise_error Konfa::UnsupportedVariableError
+
+      ENV.delete("PREF_BAD_VARIABLE")
+    end
+  end
+
+end

--- a/spec/konfa_spec.rb
+++ b/spec/konfa_spec.rb
@@ -151,7 +151,7 @@ describe Konfa do
         MyTestKonfa.init_with(:something, 'arg')
       }.to change {
         MyTestKonfa.send(:initializer)
-      }.from(nil).to(['init_with_something', 'arg'])
+      }.from(nil).to([:init_with_something, 'arg'])
     end
 
     it 'should return self' do

--- a/spec/konfa_spec.rb
+++ b/spec/konfa_spec.rb
@@ -66,7 +66,7 @@ describe Konfa do
       expect(MyTestKonfa.dump.keys).to eq MyTestKonfa.variables
     end
 
-    it "dumpes the current state" do
+    it "dupes the current state" do
       dumped = MyTestKonfa.dump
       expect(dumped).not_to equal MyTestKonfa.dump
     end

--- a/spec/konfa_spec.rb
+++ b/spec/konfa_spec.rb
@@ -1,6 +1,4 @@
-$: << File.join(File.dirname(File.dirname(__FILE__)), "lib")
-
-require 'konfa'
+require_relative 'spec_helper'
 
 class MyTestKonfa < Konfa::Base
   class << self

--- a/spec/rspec_spec.rb
+++ b/spec/rspec_spec.rb
@@ -1,6 +1,4 @@
-$: << File.join(File.dirname(File.dirname(__FILE__)), "lib")
-
-require 'konfa'
+require_relative 'spec_helper'
 require 'konfa/rspec'
 
 class MyKonfa < Konfa::Base

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,33 @@
 $: << File.join(File.dirname(File.dirname(__FILE__)), "lib")
 
 require 'konfa'
+
+class MyTestKonfa < Konfa::Base
+  class << self
+    def env_variable_prefix
+      'PREF_'
+    end
+
+    def allowed_variables
+      {
+        :my_var         => 'default value',
+        :default_is_nil => nil
+      }
+    end
+  end
+end
+
+class MyOtherTestKonfa < Konfa::Base
+  class << self
+    def env_variable_prefix
+      'OTHER_PREF_'
+    end
+
+    def allowed_variables
+      {
+        :my_var         => 'other default',
+        :default_is_nil => 'no it is not'
+      }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,33 +1,3 @@
 $: << File.join(File.dirname(File.dirname(__FILE__)), "lib")
 
 require 'konfa'
-
-class MyTestKonfa < Konfa::Base
-  class << self
-    def env_variable_prefix
-      'PREF_'
-    end
-
-    def allowed_variables
-      {
-        :my_var         => 'default value',
-        :default_is_nil => nil
-      }
-    end
-  end
-end
-
-class MyOtherTestKonfa < Konfa::Base
-  class << self
-    def env_variable_prefix
-      'OTHER_PREF_'
-    end
-
-    def allowed_variables
-      {
-        :my_var         => 'other default',
-        :default_is_nil => 'no it is not'
-      }
-    end
-  end
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+$: << File.join(File.dirname(File.dirname(__FILE__)), "lib")
+
+require 'konfa'


### PR DESCRIPTION
All initialization is now deferred by default (initialization happens when reading a config variable or explicity calling #init)

An initializer method should be declared in the configuration class and registered by calling #initialize_with(:method_name, *args).