### PR TITLE
let_config() accepts string values only

### DIFF
--- a/konfa.gemspec
+++ b/konfa.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
   s.name        = 'konfa'
-  s.version     = '0.4.1'
+  s.version     = '0.4.2'
   s.date        = '2014-01-12'
   s.summary     = "Application configuration"
   s.description = "Helps you avoid common pitfalls when dealing with app config"

--- a/lib/konfa/rspec.rb
+++ b/lib/konfa/rspec.rb
@@ -8,7 +8,7 @@ module Konfa
 
       def let_config(variable, value, use_klass=@konfa_klass)
         raise Konfa::UnsupportedVariableError.new(variable) unless use_klass.allowed_variables.has_key?(variable)
-        raise Konfa::RSpec::BadValueError.new(value) unless value.kind_of?(String)
+        raise Konfa::RSpec::BadValueError.new(value) unless value.kind_of?(String) || value.kind_of?(NilClass)
 
         unless @konfa_stubbed_klasses.include?(use_klass)
           allow(use_klass).to receive(:get).and_call_original
@@ -31,7 +31,7 @@ module Konfa
       end
 
       def to_s
-        "Konfa requires values to be of type String, you passed #{@type}"
+        "Konfa requires values to be of type String (or NilClass), you passed #{@type}"
       end
     end
   end

--- a/lib/konfa/rspec.rb
+++ b/lib/konfa/rspec.rb
@@ -8,6 +8,7 @@ module Konfa
 
       def let_config(variable, value, use_klass=@konfa_klass)
         raise Konfa::UnsupportedVariableError.new(variable) unless use_klass.allowed_variables.has_key?(variable)
+        raise Konfa::RSpec::BadValueError.new(value) unless value.kind_of?(String)
 
         unless @konfa_stubbed_klasses.include?(use_klass)
           allow(use_klass).to receive(:get).and_call_original
@@ -21,6 +22,16 @@ module Konfa
         variables.each_pair do |var, val|
           let_config(var, val, use_klass)
         end
+      end
+    end
+
+    class BadValueError < StandardError
+      def initialize(msg)
+        @type = msg.class.name
+      end
+
+      def to_s
+        "Konfa requires values to be of type String, you passed #{@type}"
       end
     end
   end

--- a/spec/rspec_spec.rb
+++ b/spec/rspec_spec.rb
@@ -71,6 +71,12 @@ describe Konfa::RSpec do
       expect(MyKonfa.get(:my_var_3)).to eq 'overridden value 3'
       expect(MyOtherKonfa.get(:my_var_3)).to eq 'other overridden value 3'
     end
+
+    it 'requires value to be of type string' do
+      expect {
+        let_config(:my_var_1, true)
+      }.to raise_error Konfa::RSpec::BadValueError
+    end
   end
 
   context 'with_config' do

--- a/spec/rspec_spec.rb
+++ b/spec/rspec_spec.rb
@@ -72,10 +72,24 @@ describe Konfa::RSpec do
       expect(MyOtherKonfa.get(:my_var_3)).to eq 'other overridden value 3'
     end
 
-    it 'requires value to be of type string' do
-      expect {
-        let_config(:my_var_1, true)
-      }.to raise_error Konfa::RSpec::BadValueError
+    context 'value' do
+      it 'must be of type string' do
+        expect {
+          let_config(:my_var_1, true)
+        }.to raise_error Konfa::RSpec::BadValueError
+      end
+
+      it 'may be a string' do
+        expect {
+          let_config(:my_var_1, 'a string')
+        }.to_not raise_error
+      end
+
+      it 'may be nil' do
+        expect {
+          let_config(:my_var_1, nil)
+        }.to_not raise_error
+      end
     end
   end
 


### PR DESCRIPTION
This change helps avoiding that overridden values bugs to go undetected. Here's a scenario

RSpec code
```ruby
it 'is off' do
   let_config(:do_something, false)   # Illegal value - in production konfa would convert this to string
   # ...
end
```

Tested code:
```ruby
something() if MyConfig.get(:do_something)   # Value of "false" or "no" will be true
``` 